### PR TITLE
Modify the double press and long press behavior in settings

### DIFF
--- a/main/user_settings.h
+++ b/main/user_settings.h
@@ -78,7 +78,8 @@ class UserSettings {
     /// @brief Loads settings from persistent storage.
     void loadSettings();
 
-    void advanceToNextButton();
+    void moveToNextButton();
+    void moveToPreviousButton();
     void pressFocusedButton();
 
 public:


### PR DESCRIPTION
Long press now activates the focused button. Double press moves the focus to the previous item in the focus group. When you exit a screen it will automatically focus the Back/Exit button as a convenience.